### PR TITLE
Created a basic RuntimeObject record.

### DIFF
--- a/BassScript/BassScript.csproj
+++ b/BassScript/BassScript.csproj
@@ -9,6 +9,7 @@
 		<RootNamespace>BassClefStudio.BassScript</RootNamespace>
 		
 		<PackageId>BassScript</PackageId>
+		<Version>1.0.1</Version>
 		<Authors>BassClefStudio</Authors>
 		<Description>Provides a compiler/interpreter and basic runtime for a loosely-typed scripting language that can be easily added and extended in other projects.</Description>
 		<PackageProjectUrl>https://github.com/bassclefstudio/BassScript</PackageProjectUrl>

--- a/BassScript/Runtime/IRuntimeObject.cs
+++ b/BassScript/Runtime/IRuntimeObject.cs
@@ -22,6 +22,26 @@ namespace BassClefStudio.BassScript.Runtime
     }
 
     /// <summary>
+    /// Provides a basic <see cref="IRuntimeObject"/> wrapper over an <see cref="IDictionary{TKey, TValue}"/> which manages a collection of key/value pairs as a complex object instead of an <see cref="IEnumerable{T}"/> of pairs.
+    /// </summary>
+    /// <param name="Data">The <see cref="IDictionary{TKey, TValue}"/> from which to create this <see cref="RuntimeObject"/>.</param>
+    public record RuntimeObject(IDictionary<string, object?> Data) : IRuntimeObject
+    {
+        /// <inheritdoc/>
+        public object? this[string key]
+        {
+            get => Data[key];
+            set => Data[key] = value;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return "{" + string.Join(", ", Data.Select(p => $"{p.Key}: {p.Value}")) + "}";
+        }
+    }
+
+    /// <summary>
     /// Represents an asynchronous method which can be a member of an <see cref="IRuntimeObject"/>.
     /// </summary>
     /// <param name="context">The <see cref="RuntimeContext"/> used as the runtime context for where this <see cref="RuntimeMethod"/> is executed.</param>


### PR DESCRIPTION
`RuntimeObject` acts as a rapper around an existing `IDictionary<string, object?>`. Useful for outputting/serializing the object as-is, preventing casting to a collection of key/value pairs.